### PR TITLE
Chapter 3: Fix destructured slot props for ProductItemList.vue

### DIFF
--- a/ch03/src/components/ProductItemList.vue
+++ b/ch03/src/components/ProductItemList.vue
@@ -20,7 +20,7 @@
           width="200"
         />
       </template>
-      <template #main="{ item, price }">
+      <template #main="{ item }">
         <div class="list-layout__item__name">{{ item.name }}</div>
         <div class="list-layout__item__description">{{ item.description }}</div>
         <div class="list-layout__item__price">{{ price }}</div>


### PR DESCRIPTION
The `price` data is not part of the slots properties. This fails to render the slot. Removal of the property from the slot properties enables it to work as it was likely intended.